### PR TITLE
Suggest some similar provider in find_provider function

### DIFF
--- a/simplemind/utils.py
+++ b/simplemind/utils.py
@@ -13,9 +13,9 @@ def find_provider(provider_name: Union[str, None]):
                 return provider_class()
     
     providers_name = [provider.NAME.lower() for provider in providers]
-    providers_founds = difflib.get_close_matches(provider_name.lower(), providers_name)
+    provider_found = difflib.get_close_matches(provider_name.lower(), providers_name, n=1) # Show only one suggestion
     
-    if providers_founds:
-        raise ValueError(f"Provider {provider_name} not found. Maybe you try to use is '{providers_founds[0]}'?")
+    if provider_found:
+        raise ValueError(f"Provider {provider_name} not found. Maybe you try to use is '{provider_found[0]}'?")
     else:
         raise ValueError(f"Provider {provider_name} not found.")

--- a/simplemind/utils.py
+++ b/simplemind/utils.py
@@ -1,3 +1,4 @@
+import difflib
 from typing import Union
 
 from .providers import providers
@@ -10,4 +11,11 @@ def find_provider(provider_name: Union[str, None]):
             if provider_class.NAME.lower() == provider_name.lower():
                 # Instantiate the provider
                 return provider_class()
-    raise ValueError(f"Provider {provider_name} not found")
+    
+    providers_name = [provider.NAME.lower() for provider in providers]
+    providers_founds = difflib.get_close_matches(provider_name.lower(), providers_name)
+    
+    if providers_founds:
+        raise ValueError(f"Provider {provider_name} not found. Maybe you try to use is '{providers_founds[0]}'?")
+    else:
+        raise ValueError(f"Provider {provider_name} not found.")

--- a/simplemind/utils.py
+++ b/simplemind/utils.py
@@ -3,6 +3,7 @@ from typing import Union
 
 from .providers import providers
 
+_PROVIDER_NAMES = [provider.NAME.lower() for provider in providers]
 
 def find_provider(provider_name: Union[str, None]):
     """Find a provider by name."""
@@ -12,8 +13,7 @@ def find_provider(provider_name: Union[str, None]):
                 # Instantiate the provider
                 return provider_class()
     
-    providers_name = [provider.NAME.lower() for provider in providers]
-    provider_found = difflib.get_close_matches(provider_name.lower(), providers_name, n=1) # Show only one suggestion
+    provider_found = difflib.get_close_matches(provider_name.lower(), _PROVIDER_NAMES, n=1) # Show only one suggestion
     
     if provider_found:
         raise ValueError(f"Provider {provider_name} not found. Maybe you try to use is '{provider_found[0]}'?")


### PR DESCRIPTION
Hello. It might be useful to suggest a provider in case the human for some reason misspells the name of the provider. It won't be found, at least suggest and approach what you really wanted to use.

Example:
```sh
ValueError: Provider llama not found. Maybe you try to use is 'ollama'?
```

In case you don't find similarity:
```sh
ValueError: Provider lladssda not found.
```

It is a Python standard library. I get the first similarity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for provider lookup, providing suggestions for similar provider names when a match is not found.

- **Bug Fixes**
	- Improved user experience with more informative error messages related to provider searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->