### PR TITLE
Add default kwargs logic into Anthropic provider, which is superseded by user entered kwargs

### DIFF
--- a/simplemind/providers/anthropic.py
+++ b/simplemind/providers/anthropic.py
@@ -79,7 +79,6 @@ class Anthropic(BaseProvider):
         response = self.client.messages.create(
             model=llm_model or self.DEFAULT_MODEL,
             messages=messages,
-            max_tokens=DEFAULT_MAX_TOKENS,
             **{**self.DEFAULT_KWARGS, **kwargs},
         )
 

--- a/simplemind/providers/anthropic.py
+++ b/simplemind/providers/anthropic.py
@@ -14,11 +14,13 @@ T = TypeVar("T", bound=BaseModel)
 PROVIDER_NAME = "anthropic"
 DEFAULT_MODEL = "claude-3-5-sonnet-20241022"
 DEFAULT_MAX_TOKENS = 1000
+DEFAULT_KWARGS = {"max_tokens": DEFAULT_MAX_TOKENS}
 
 
 class Anthropic(BaseProvider):
     NAME = PROVIDER_NAME
     DEFAULT_MODEL = DEFAULT_MODEL
+    DEFAULT_KWARGS = DEFAULT_KWARGS
 
     def __init__(self, api_key: str | None = None):
         self.api_key = api_key or settings.get_api_key(PROVIDER_NAME)
@@ -46,8 +48,7 @@ class Anthropic(BaseProvider):
         response = self.client.messages.create(
             model=conversation.llm_model or self.DEFAULT_MODEL,
             messages=messages,
-            max_tokens=DEFAULT_MAX_TOKENS,
-            **kwargs,
+            **{**self.DEFAULT_KWARGS, **kwargs},
         )
 
         # Get the response content from the Anthropic response
@@ -64,7 +65,9 @@ class Anthropic(BaseProvider):
 
     def structured_response(self, model: str, response_model: Type[T], **kwargs) -> T:
         response = self.structured_client.messages.create(
-            model=model or self.DEFAULT_MODEL, response_model=response_model, **kwargs
+            model=model or self.DEFAULT_MODEL, 
+            response_model=response_model,
+            **{**self.DEFAULT_KWARGS, **kwargs},
         )
         return response
 
@@ -77,7 +80,7 @@ class Anthropic(BaseProvider):
             model=llm_model or self.DEFAULT_MODEL,
             messages=messages,
             max_tokens=DEFAULT_MAX_TOKENS,
-            **kwargs,
+            **{**self.DEFAULT_KWARGS, **kwargs},
         )
 
         return response.content[0].text


### PR DESCRIPTION
A `DEFAULT_KWARGS` dictionary added to Anthropic provider class. Default max_tokens is inside of it. In the future, new default arguments can be added.

Before sending kwargs to the client, the default and user inputted kwargs are merged by the following pattern:
```
**{**self.DEFAULT_KWARGS, **kwargs}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new constant, `DEFAULT_KWARGS`, to streamline handling of default arguments in key methods.
  
- **Improvements**
	- Enhanced flexibility of method signatures by merging default parameters with additional arguments in `send_conversation`, `structured_response`, and `generate_text` methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->