### PR TITLE
Add default kwargs logic to Groq, OpenAI, XAI, and Ollama providers

### DIFF
--- a/simplemind/providers/groq.py
+++ b/simplemind/providers/groq.py
@@ -10,6 +10,8 @@ from ._base import BaseProvider
 
 PROVIDER_NAME = "groq"
 DEFAULT_MODEL = "llama3-8b-8192"
+DEFAULT_MAX_TOKENS = 1_000
+DEFAULT_KWARGS = {"max_tokens": DEFAULT_MAX_TOKENS}
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -17,6 +19,7 @@ T = TypeVar("T", bound=BaseModel)
 class Groq(BaseProvider):
     NAME = PROVIDER_NAME
     DEFAULT_MODEL = DEFAULT_MODEL
+    DEFAULT_KWARGS = DEFAULT_KWARGS
 
     def __init__(self, api_key: str | None = None):
         self.api_key = api_key or settings.get_api_key(PROVIDER_NAME)
@@ -48,7 +51,7 @@ class Groq(BaseProvider):
         response = self.client.chat.completions.create(
             model=conversation.llm_model or self.DEFAULT_MODEL,
             messages=messages,
-            **kwargs,
+            **{**self.DEFAULT_KWARGS, **kwargs},
         )
 
         # Get the response content from the Groq response
@@ -73,7 +76,7 @@ class Groq(BaseProvider):
             messages=messages,
             response_model=response_model,
             model=kwargs.pop("llm_model", self.DEFAULT_MODEL),
-            **kwargs,
+            **{**self.DEFAULT_KWARGS, **kwargs},
         )
         return response
 
@@ -91,7 +94,7 @@ class Groq(BaseProvider):
         response = self.client.chat.completions.create(
             messages=messages,
             model=llm_model or self.DEFAULT_MODEL,
-            **kwargs,
+            **{**self.DEFAULT_KWARGS, **kwargs},
         )
 
         return response.choices[0].message.content

--- a/simplemind/providers/openai.py
+++ b/simplemind/providers/openai.py
@@ -12,11 +12,14 @@ T = TypeVar("T", bound=BaseModel)
 
 PROVIDER_NAME = "openai"
 DEFAULT_MODEL = "gpt-4o-mini"
+DEFAULT_MAX_TOKENS = 1_000
+DEFAULT_KWARGS = {"max_tokens": DEFAULT_MAX_TOKENS}
 
 
 class OpenAI(BaseProvider):
     NAME = PROVIDER_NAME
     DEFAULT_MODEL = DEFAULT_MODEL
+    DEFAULT_KWARGS = DEFAULT_KWARGS
 
     def __init__(self, api_key: str | None = None):
         self.api_key = api_key or settings.get_api_key(PROVIDER_NAME)
@@ -42,7 +45,9 @@ class OpenAI(BaseProvider):
         ]
 
         response = self.client.chat.completions.create(
-            model=conversation.llm_model or DEFAULT_MODEL, messages=messages, **kwargs
+            model=conversation.llm_model or DEFAULT_MODEL,
+            messages=messages,
+            **{**self.DEFAULT_KWARGS, **kwargs}
         )
 
         # Get the response content from the OpenAI response
@@ -74,7 +79,7 @@ class OpenAI(BaseProvider):
             messages=messages,
             model=llm_model or self.DEFAULT_MODEL,
             response_model=response_model,
-            **kwargs,
+            **{**self.DEFAULT_KWARGS, **kwargs}
         )
         return response
 
@@ -84,6 +89,8 @@ class OpenAI(BaseProvider):
             {"role": "user", "content": prompt},
         ]
         response = self.client.chat.completions.create(
-            messages=messages, model=llm_model or self.DEFAULT_MODEL, **kwargs
+            messages=messages,
+            model=llm_model or self.DEFAULT_MODEL,
+            **{**self.DEFAULT_KWARGS, **kwargs}
         )
         return response.choices[0].message.content

--- a/simplemind/providers/xai.py
+++ b/simplemind/providers/xai.py
@@ -10,11 +10,13 @@ PROVIDER_NAME = "xai"
 DEFAULT_MODEL = "grok-beta"
 BASE_URL = "https://api.x.ai/v1"
 DEFAULT_MAX_TOKENS = 1000
+DEFAULT_KWARGS = {"max_tokens": DEFAULT_MAX_TOKENS}
 
 
 class XAI(BaseProvider):
     NAME = PROVIDER_NAME
     DEFAULT_MODEL = DEFAULT_MODEL
+    DEFAULT_KWARGS = DEFAULT_KWARGS
 
     def __init__(self, api_key: str | None = None):
         self.api_key = api_key or settings.get_api_key(PROVIDER_NAME)
@@ -45,7 +47,7 @@ class XAI(BaseProvider):
         response = self.client.chat.completions.create(
             model=conversation.llm_model or self.DEFAULT_MODEL,
             messages=messages,
-            **kwargs,
+            **{**self.DEFAULT_KWARGS, **kwargs},
         )
 
         # Get the response content from the OpenAI response
@@ -71,7 +73,7 @@ class XAI(BaseProvider):
         response = self.client.chat.completions.create(
             messages=messages,
             model=llm_model or self.DEFAULT_MODEL,
-            **kwargs,
+            **{**self.DEFAULT_KWARGS, **kwargs},
         )
 
         return response.choices[0].message.content


### PR DESCRIPTION
Default kwargs logic that was added to Anthropic by #23. A similar logic (almost same) added to other providers except Gemini. Gemini api seems more intricate. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a default maximum tokens setting across multiple classes, enhancing API call flexibility.
	- Added support for additional parameters in API calls via `**kwargs` in the `send_conversation`, `structured_response`, and `generate_text` methods for improved configurability.
  
- **Bug Fixes**
	- Ensured consistent application of default parameters across API interactions, enhancing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->