### PR TITLE
Add cooking recipe example 

### DIFF
--- a/examples/cooking_recipe_example.py
+++ b/examples/cooking_recipe_example.py
@@ -1,0 +1,40 @@
+from pydantic import BaseModel
+import simplemind as sm
+
+
+class InstructionStep(BaseModel):
+    step_number: int
+    instruction: str
+
+class RecipeIngredient(BaseModel):
+    name: str
+    quantity: float
+    unit: str
+
+class Recipe(BaseModel):
+    name: str
+    ingredients: list[RecipeIngredient]
+    instructions: list[InstructionStep]
+    
+    def __str__(self) -> str:
+        output = f"\n=== {self.name.upper()} ===\n\n"
+        
+        output += "INGREDIENTS:\n"
+        for ing in self.ingredients:
+            output += f"• {ing.quantity} {ing.unit} {ing.name}\n"
+        
+        output += "\nINSTRUCTIONS:\n"
+        for step in self.instructions:
+            output += f"{step.step_number}. {step.instruction}\n"
+        
+        return output
+    
+
+recipe = sm.generate_data(
+    "Write a recipe for chocolate chip cookies",
+    llm_model="gpt-4o-mini",
+    llm_provider="openai",
+    response_model=Recipe,
+)
+
+print(recipe)

--- a/examples/cooking_recipe_example.py
+++ b/examples/cooking_recipe_example.py
@@ -38,3 +38,29 @@ recipe = sm.generate_data(
 )
 
 print(recipe)
+# Expected output is something like this:
+#
+# === CHOCOLATE CHIP COOKIES ===
+#
+# INGREDIENTS:
+# • 2.25 cups all-purpose flour
+# • 1.0 teaspoon baking soda
+# • 0.5 teaspoon salt
+# • 1.0 cup unsalted butter
+# • 0.75 cup sugar
+# • 0.75 cup brown sugar
+# • 1.0 teaspoon vanilla extract
+# • 2.0 large eggs
+# • 2.0 cups semi-sweet chocolate chips
+#
+# INSTRUCTIONS:
+# 1. Preheat your oven to 350°F (175°C).
+# 2. In a small bowl, combine flour, baking soda, and salt; set aside.
+# 3. In a large bowl, cream together the butter, sugar, and brown sugar until smooth.
+# 4. Beat in the vanilla extract and eggs, one at a time.
+# 5. Gradually blend in the flour mixture until just combined.
+# 6. Stir in the chocolate chips.
+# 7. Drop by rounded tablespoon onto ungreased cookie sheets.
+# 8. Bake for 9 to 11 minutes, or until edges are golden.
+# 9. Let cool on the cookie sheet for a few minutes before transferring to wire racks to cool completely.
+

--- a/examples/math_plugin.py
+++ b/examples/math_plugin.py
@@ -2,7 +2,7 @@ from _context import sm
 
 
 class MathPlugin(sm.BasePlugin):
-    def send_hook(self, conversation: sm.Conversation):
+    def pre_send_hook(self, conversation: sm.Conversation):
         last_user_message = conversation.get_last_message(role="user")
         if last_user_message is None:
             return


### PR DESCRIPTION
- I copy-pasted the cooking recipe example from readme and added a pretty string formatted on top of that.

- Fixed a minor bug in math plugin example, which was caused by a previous change in pre_send_hook logic

Idea: I think it can be nice to add a send_wrapper_hook logic with plugins. By that way, plugins can disable send to LLM's. For the case of math plugin, it calculate the math expression, but still send the prompt and the calculation result to the LLM. For this and some other applications, it can be nice if plugins can divert the way of the conversation if it detects certain signifiers in the prompt (e.g. 'calculate', '@Web (like in Cursor))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a structured representation of recipes with a new example for cooking recipes.
	- Added functionality to evaluate mathematical expressions upon user request.

- **Bug Fixes**
	- Improved error handling for mathematical expression evaluations, providing clearer feedback to users. 

- **Refactor**
	- Renamed method in the MathPlugin class for clarity on its functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->