### PR TITLE
Fix minor bug. generate_data() now passes kwargs to provider

### DIFF
--- a/simplemind/__init__.py
+++ b/simplemind/__init__.py
@@ -94,6 +94,7 @@ def generate_data(
         prompt=prompt,
         llm_model=llm_model,
         response_model=response_model,
+        **kwargs,
     )
 
 


### PR DESCRIPTION
It wasn't possible to pass arguments like max_tokens from generate_data() API to providers. It was because generate_data() doesn't relay or use the kwargs argument. This PR fixes this. 