### PR TITLE
fix: `prepend_system_message` use system role by default

### DIFF
--- a/examples/simple_memory.py
+++ b/examples/simple_memory.py
@@ -13,7 +13,7 @@ class SimpleMemoryPlugin:
 
     def initialize_hook(self, conversation: sm.Conversation):
         for m in self.yield_memories():
-            conversation.prepend_system_message(role="system", text=m)
+            conversation.prepend_system_message(text=m)
 
 
 conversation = sm.create_conversation(llm_model="grok-beta", llm_provider="xai")

--- a/simplemind/models.py
+++ b/simplemind/models.py
@@ -117,10 +117,10 @@ class Conversation(SMBaseModel):
                     pass
 
     def prepend_system_message(
-        self, role: MESSAGE_ROLE, text: str, meta: Dict[str, Any] | None = None
+        self, text: str, meta: Dict[str, Any] | None = None
     ):
         """Prepend a system message to the conversation."""
-        self.messages = [Message(role=role, text=text, meta=meta or {})] + self.messages
+        self.messages = [Message(role="system", text=text, meta=meta or {})] + self.messages
 
     def add_message(
         self, role: MESSAGE_ROLE, text: str, meta: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
I thought that with `prepend_system_message` it will imply that the message is a message with a "system" role. This PR defaults the role to "system". Otherwise this function would be too similar to `add_message` ? Maybe this was intended.