### PR TITLE
fix: anthropic system message

### DIFF
--- a/simplemind/providers/anthropic.py
+++ b/simplemind/providers/anthropic.py
@@ -55,10 +55,10 @@ class Anthropic(BaseProvider):
         """Send a conversation to the Anthropic API."""
         from ..models import Message
 
-        system_prompt = filter(
-            lambda msg: msg.role == "system", conversation.messages
-        )
-
+        system_messages = [msg for msg in conversation.messages if msg.role == "system"]
+        if len(system_messages) > 1:
+            logger.warning("Multiple system messages found. Using the first one.")
+        system_prompt = system_messages[0] if system_messages else None
         messages = [
             {"role": msg.role, "content": msg.text}
             for msg in conversation.messages

--- a/simplemind/providers/anthropic.py
+++ b/simplemind/providers/anthropic.py
@@ -1,5 +1,5 @@
 from functools import cached_property
-from typing import TYPE_CHECKING, Iterator, Type, TypeVar
+from typing import TYPE_CHECKING, Type, TypeVar, Iterator
 
 import instructor
 from pydantic import BaseModel


### PR DESCRIPTION
I got this error while running with the anthropic backend. 

```
BadRequestError: Error code: 400 - {'type': 'error', 'error': {'type':
'invalid_request_error', 'message': 'messages: Unexpected role "system". The Messages
API accepts a top-level `system` parameter, not "system" as an input message role.'}}
```

This PR adds the message with the role  "system" on the API's system parameter
https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/system-prompts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `send_conversation` method to filter messages, improving the clarity of conversation handling.
  
- **Bug Fixes**
	- Improved error handling for missing packages and API keys.

- **Refactor**
	- Reformatted method signatures for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->