### PR TITLE
use inference profile with Claude 3.5 on Bedrock

### DIFF
--- a/simplemind/providers/amazon.py
+++ b/simplemind/providers/amazon.py
@@ -10,7 +10,7 @@ from ..settings import settings
 T = TypeVar("T", bound=BaseModel)
 
 PROVIDER_NAME = "amazon"
-DEFAULT_MODEL = "anthropic.claude-3-5-sonnet-20241022-v2:0"
+DEFAULT_MODEL = "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
 DEFAULT_MAX_TOKENS = 5_000
 
 


### PR DESCRIPTION
For Claude 3.5 we need to specify inference profile rather than model ID for inference to work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the model identifier for improved functionality and access.

- **Bug Fixes**
	- No bug fixes were included in this release. 

- **Documentation**
	- No changes to documentation were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->