### PR TITLE
fix: anthropic system message

### DIFF
--- a/simplemind/providers/anthropic.py
+++ b/simplemind/providers/anthropic.py
@@ -72,7 +72,7 @@ class Anthropic(BaseProvider):
         ]
 
         response = self.client.messages.create(
-            system=system_prompt.text,
+            system=system_prompt.text if system_prompt else None,
             model=conversation.llm_model or self.DEFAULT_MODEL,
             messages=messages,
             **{**self.DEFAULT_KWARGS, **kwargs},


### PR DESCRIPTION
Updated version of https://github.com/kennethreitz/simplemind/pull/37 ! 
The system message needed to be a `str`. Could you have a look now! It works on my environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of system messages in conversations, ensuring only the first system message is used for API calls.
	- System prompt can now be included in API requests.

- **Bug Fixes**
	- Added logging for multiple system messages to avoid potential issues in conversation flow. 

- **Refactor**
	- Reordered import statements for better clarity. 
	- Reformatted method signature for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->