### PR TITLE
Added a `_llm_providers` type using Literal to define valid LLM provider strings.

### DIFF
--- a/simplemind/__init__.py
+++ b/simplemind/__init__.py
@@ -1,6 +1,7 @@
 import inspect
 from typing import Callable, List, Type
 
+from . import providers
 from .models import BaseModel, BasePlugin, Conversation
 from .settings import settings
 from .utils import find_provider
@@ -16,7 +17,7 @@ class Session:
     def __init__(
         self,
         *,
-        llm_provider: str = settings.DEFAULT_LLM_PROVIDER,
+        llm_provider: str | providers._llm_providers | None = settings.DEFAULT_LLM_PROVIDER,
         llm_model: str | None = None,
         **kwargs,
     ):
@@ -58,7 +59,7 @@ class Session:
 def create_conversation(
     *,
     llm_model: str | None = None,
-    llm_provider: str | None = None,
+    llm_provider: str | providers._llm_providers | None = None,
     plugins: List[BasePlugin] | None = None,
     **kwargs,
 ) -> Conversation:
@@ -81,7 +82,7 @@ def generate_data(
     prompt: str,
     *,
     llm_model: str | None = None,
-    llm_provider: str | None = None,
+    llm_provider: str | providers._llm_providers | None = None,
     response_model: Type[BaseModel],
     **kwargs,
 ) -> BaseModel:
@@ -103,7 +104,7 @@ def generate_text(
     prompt: str,
     *,
     llm_model: str | None = None,
-    llm_provider: str | None = None,
+    llm_provider: str | providers._llm_providers | None = None,
     stream: bool = False,
     **kwargs,
 ) -> str:
@@ -129,7 +130,7 @@ def enable_logfire() -> None:
     settings.logging.enable_logfire()
 
 def tool(
-    llm_provider: str | None = None,
+    llm_provider: str | providers._llm_providers | None = None,
     llm_model: str | None = None,
 ):
     provider = find_provider(llm_provider or settings.DEFAULT_LLM_PROVIDER)

--- a/simplemind/providers/__init__.py
+++ b/simplemind/providers/__init__.py
@@ -1,4 +1,4 @@
-from typing import List, Type
+from typing import List, Type, Literal
 
 from ._base import BaseProvider
 from ._base_tools import BaseTool
@@ -18,6 +18,10 @@ providers: List[Type[BaseProvider]] = [
     Ollama,
     XAI,
     Amazon,
+]
+
+_llm_providers = Literal[
+    "anthropic", "gemini", "groq", "openai", "ollama", "xai", "amazon"
 ]
 
 __all__ = [


### PR DESCRIPTION
It does not lose the essence of validating that the supplier matches. Although it was necessary to incorporate it. I have defined the valid providers using the Literal type. 

![image](https://github.com/user-attachments/assets/bdcb39f7-6db8-4686-a2bd-5139f98394d6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility of the `llm_provider` parameter to accept a broader range of input types across various functions.
	- Introduced a new type alias for `_llm_providers`, specifying a fixed set of provider names.

- **Bug Fixes**
	- Minor formatting adjustment made to improve code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->