### PR TITLE
Missing dependency when using Gemini

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ full = [
 ]
 amazon = ["boto3", "botocore", "anthropic"]
 anthropic = ["anthropic"]
-gemini = ["google-generativeai"]
+gemini = ["google-generativeai", "jsonref"]
 groq = ["groq"]
 ollama = ["openai"]
 openai = ["openai"]


### PR DESCRIPTION
When trying [one of the examples](https://github.com/kennethreitz/simplemind?tab=readme-ov-file#structured-data-with-pydantic) listed in the README using Gemini, the code throws a RuntimeError:

```
RuntimeError: Failed to send structured response to Gemini API: No module named 'jsonref'
```

Further investigation lead me to the Instructor README page that explains that `jsonref` is required when using Gemini:

>  Gemini tool calling also requires `jsonref` to be installed. [ref](https://github.com/instructor-ai/instructor/?tab=readme-ov-file#using-gemini-models)

This pull request fix this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added `jsonref` as an optional dependency for the `gemini` group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->